### PR TITLE
Fixed comparison arithmetic context and comparison order

### DIFF
--- a/NextcloudBackup.sh
+++ b/NextcloudBackup.sh
@@ -126,11 +126,11 @@ echo
 #
 # Delete old backups
 #
-if [ ${maxNrOfBackups} != 0 ]
+if (( ${maxNrOfBackups} != 0 ))
 then	
 	nrOfBackups=$(ls -l ${backupMainDir} | grep -c ^d)
 	
-	if [  ${maxNrOfBackups} > ${nrOfBackups} ]
+	if (( ${nrOfBackups} > ${maxNrOfBackups} ))
 	then
 		echo "Removing old backups..."
 		ls -t ${backupMainDir} | tail -$(( nrOfBackups - maxNrOfBackups )) | while read dirToRemove; do


### PR DESCRIPTION
This commit fixes two issues:

1. Using [arithmetic context](http://mywiki.wooledge.org/ArithmeticExpression)  for Bash
2. Comparing number of backups for deletion in the right order: We want to delete backups when the *number_of_backups* is bigger than the *number_of_maximum_backups* 